### PR TITLE
refactor(denot): start denot with unvisited map instead of visited map

### DIFF
--- a/src/core/DenotRecursive.h
+++ b/src/core/DenotRecursive.h
@@ -14,7 +14,6 @@ public:
         m_maxRecursionDepth = backwardNfa.maxRecursiveDepth();
     }
     ~DenotRecursive() override = default;
-
     PowersetUniquePtr run() override;
 
     [[nodiscard]] int totalIterations() const override { return m_iterations; }
@@ -25,6 +24,7 @@ private:
     const BackwardNFA& m_backwardNfa {};
     int m_maxRecursionDepth {};
 
+    std::vector<Powerset> initializeUnvisitedMap() const;
     PowersetUniquePtr denot(
         int state,
         const Poly& P,
@@ -33,7 +33,4 @@ private:
         int recursionDepth,
         bool isSing
     );
-
-    void addDisjunct(std::vector<Powerset>& V, int state, const Poly& P) const;
-    static const Powerset& getVisitedPowerset(std::vector<Powerset>& V, int state);
 };


### PR DESCRIPTION
Replaced the previous approach of tracking visited disjuncts with an unvisited map. The algorithm now begins with a map of disjuncts to be visited (unvisited map), initializing it with the state denotations at the start.